### PR TITLE
Fix route function naming conflict

### DIFF
--- a/umls_similarity_web.py
+++ b/umls_similarity_web.py
@@ -100,7 +100,7 @@ def create_app(args):
     """
 
     @app.route("/", methods=["GET"])
-    def index():
+    def index_page():
         return render_template_string(
             TEMPLATE,
             results=None,


### PR DESCRIPTION
## Summary
- rename `index` route handler to `index_page` to avoid clobbering FAISS index

## Testing
- `python -m py_compile umls_similarity_web.py`
- `python -m py_compile build_hnsw_index.py merge_embeddings.py precompute.py pure_transformers_umls.py umls_similarity_search.py`


------
https://chatgpt.com/codex/tasks/task_e_686bfedc784c8327817d13416885dab6