### PR TITLE
Improve UMLS similarity UI

### DIFF
--- a/umls_similarity_web.py
+++ b/umls_similarity_web.py
@@ -1,6 +1,7 @@
 # HTML interface for UMLS similarity search
 
 import argparse
+import ast
 import faiss
 import pandas as pd
 import numpy as np
@@ -29,11 +30,22 @@ def parse_args():
 
 def load_metadata(path):
     df = pd.read_csv(path, usecols=["CUI", "STR", "STY"]).dropna()
-    return (
-        df["CUI"].astype(str).tolist(),
-        df["STR"].astype(str).tolist(),
-        df["STY"].astype(str).tolist(),
-    )
+
+    cuis = df["CUI"].astype(str).tolist()
+    terms = df["STR"].astype(str).tolist()
+    stys_raw = df["STY"].astype(str).tolist()
+    stys = []
+    for s in stys_raw:
+        try:
+            parsed = ast.literal_eval(s)
+            if isinstance(parsed, list):
+                stys.append(parsed)
+            else:
+                stys.append([str(parsed)])
+        except Exception:
+            stys.append([s])
+
+    return (cuis, terms, stys)
 
 
 def encode_query(text, tokenizer, model, device):
@@ -60,12 +72,19 @@ def create_app(args):
     TEMPLATE = """
     <!doctype html>
     <title>UMLS Similarity Search</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 40px; }
+      table { border-collapse: collapse; }
+      th, td { padding: 4px 8px; border: 1px solid #ccc; }
+      th { background-color: #f2f2f2; }
+    </style>
     <h1>UMLS Similarity Search</h1>
     <form method="post" action="/search">
       <label>Query:<br><input type="text" name="query" size="60" required></label><br><br>
       <label>Number of results:<br><input type="number" name="top_k" value="{{default_top_k}}" min="1"></label><br><br>
-      <label>Semantic Types (comma separated, optional):<br>
-        <input type="text" name="semantic_types" size="60" value="{{semantic_types_text}}">
+      <label>Maximum score (optional):<br>
+        <input type="number" name="max_score" step="any" placeholder="e.g. 0.5">
+        <small>Increase to allow more distant matches</small>
       </label><br><br>
       <input type="submit" value="Search">
     </form>
@@ -84,7 +103,7 @@ def create_app(args):
     <table border="1" cellpadding="5" cellspacing="0">
       <tr><th>Rank</th><th>CUI</th><th>Term</th><th>Semantic Type</th><th>Score</th></tr>
       {% for r in results %}
-      <tr class="result-row" data-sty="{{r[2]}}">
+      <tr class="result-row" data-sty="{{r[4]}}">
         <td>{{loop.index}}</td><td>{{r[0]}}</td><td>{{r[1]}}</td><td>{{r[2]}}</td><td>{{"%.4f"|format(r[3])}}</td>
       </tr>
       {% endfor %}
@@ -108,7 +127,6 @@ def create_app(args):
             TEMPLATE,
             results=None,
             default_top_k=DEFAULT_TOP_K,
-            semantic_types_text="",
             sty_set=[],
         )
 
@@ -119,28 +137,34 @@ def create_app(args):
             top_k = int(request.form.get("top_k", DEFAULT_TOP_K))
         except ValueError:
             top_k = DEFAULT_TOP_K
-        sty_input = request.form.get("semantic_types", "")
-        semantic_types = [s.strip() for s in sty_input.split(",") if s.strip()]
+        max_score_in = request.form.get("max_score", "").strip()
+        try:
+            max_score = float(max_score_in) if max_score_in else None
+        except ValueError:
+            max_score = None
 
         q_vec = encode_query(query, tokenizer, model, device)
         D, I = index.search(q_vec, max(top_k * 5, top_k))
 
         results = []
+        sty_set = set()
         for idx, score in zip(I[0], D[0]):
-            sty = stys[idx]
-            if not semantic_types or sty in semantic_types:
-                results.append((cuis[idx], terms[idx], sty, float(score)))
-                if len(results) >= top_k:
-                    break
+            if len(results) >= top_k:
+                break
+            if max_score is not None and score > max_score:
+                continue
+            sty_list = stys[idx]
+            sty_set.update(sty_list)
+            sty_str = ", ".join(sty_list)
+            results.append((cuis[idx], terms[idx], sty_str, float(score), sty_list[0]))
 
-        sty_set = sorted({r[2] for r in results})
+        sty_set = sorted(sty_set)
 
         return render_template_string(
             TEMPLATE,
             results=results,
             query=query,
             default_top_k=top_k,
-            semantic_types_text=sty_input,
             sty_set=sty_set,
         )
 


### PR DESCRIPTION
## Summary
- parse STY field so semantic types show without brackets
- style web interface and add score filter input
- remove initial semantic type filter
- show parsed semantic types in CLI output

## Testing
- `python -m py_compile umls_similarity_web.py umls_similarity_search.py`

------
https://chatgpt.com/codex/tasks/task_e_686c052b5b2083278b4e87696ac02042