### PR TITLE
Fix query score scaling

### DIFF
--- a/umls_similarity_search.py
+++ b/umls_similarity_search.py
@@ -58,6 +58,9 @@ def encode_query(text, tokenizer, model, device):
         out = model(**enc)
         # out.last_hidden_state is (1, L, D); we take the [CLS] token at position 0
         cls_emb = out.last_hidden_state[:, 0, :].cpu().numpy().astype("float32")
+
+    # normalize so search distances are comparable to the index vectors
+    faiss.normalize_L2(cls_emb)
     return cls_emb  # shape (1, D)
 
 def main():

--- a/umls_similarity_web.py
+++ b/umls_similarity_web.py
@@ -53,6 +53,9 @@ def encode_query(text, tokenizer, model, device):
     with torch.no_grad():
         out = model(**enc)
         cls_emb = out.last_hidden_state[:, 0, :].cpu().numpy().astype("float32")
+
+    # normalize query so distance scores align with the index vectors
+    faiss.normalize_L2(cls_emb)
     return cls_emb
 
 


### PR DESCRIPTION
## Summary
- keep search query vectors on the same scale as indexed embeddings by applying `faiss.normalize_L2`
- update both CLI and web search

## Testing
- `python3 -m py_compile umls_similarity_search.py umls_similarity_web.py`

------
https://chatgpt.com/codex/tasks/task_e_686c080adff083279acce274ccc7071d