### PR TITLE
Remove unused DataFrame in precompute.py

### DIFF
--- a/precompute.py
+++ b/precompute.py
@@ -80,8 +80,6 @@ def main():
     # 1) Load & filter MRCONSO
     conso = load_conso(args.mrconso)
     # conso is [(CUI,STR),...]
-    # build DataFrame
-    df_conso = pd.DataFrame(conso, columns=["CUI","STR"])
 
     # 2) Load MRSTY and aggregate per CUI
     sty_map = load_sty(args.mrsty)


### PR DESCRIPTION
## Summary
- remove creation of `df_conso` which wasn't used
- confirm pyflakes no longer reports the unused variable

## Testing
- `pyflakes precompute.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab420bb10832790272067e240ff52